### PR TITLE
return the object from setReturnPath

### DIFF
--- a/ESimpleEmailServiceMessage.php
+++ b/ESimpleEmailServiceMessage.php
@@ -83,6 +83,7 @@ final class ESimpleEmailServiceMessage {
 
 	function setReturnPath($returnpath) {
 		$this->returnpath = $returnpath;
+		return $this;
 	}
 
 	function setSubject($subject) {


### PR DESCRIPTION
There was a small mistake with setReturnPath, as it didn't return the ESimpleEmailServiceMessage object back when called.
